### PR TITLE
Add logging for failed deletions and make log file path configurable

### DIFF
--- a/logremovedfile.sh
+++ b/logremovedfile.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-# Define the log file location
-LOG_FILE="$HOME/Desktop/removed.log"
+# Set log file path from environment variable or use default
+LOG_FILE="${REMOVE_LOG_PATH:-$HOME/.local/logs/removed.log}"
 
-# Create the log file if it doesn't exist
+# Create log directory if it doesn't exist
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Create the log file if it doesn't exist, exit if creation fails
 if [ ! -f "$LOG_FILE" ]; then
-    touch "$LOG_FILE"
+    touch "$LOG_FILE" || {
+        echo "Failed to create log file at $LOG_FILE" >&2
+        exit 1
+    }
 fi
 
 # Check if the number of arguments is zero
@@ -26,14 +32,13 @@ fi
 # Loop through all provided arguments
 for FILE in "$@"; do
     if [ -e "$FILE" ]; then
-        # If not in silent mode, echo details
+        # Log deletion if not in silent mode
         if [ "$SILENT" = false ]; then
             echo "$(date) - User: $(whoami) - Removed: $FILE" >> "$LOG_FILE"
         fi
-        # Remove the file
         rm -rf "$FILE"
     else
         echo "$FILE does not exist." >&2
+        echo "$(date) - User: $(whoami) - Failed to remove (not found): $FILE" >> "$LOG_FILE"
     fi
 done
-


### PR DESCRIPTION
Logs failed deletion attempts to the log file

Allows setting a custom log file path via REMOVE_LOG_PATH

Defaults to ```~/.local/logs/removed.log``` if not set